### PR TITLE
Old style exceptions --> new style for Python 3

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,9 +1,0 @@
-workflow "New workflow" {
-  on = "push"
-  resolves = ["Upgrade to Python 3"]
-}
-
-action "Upgrade to Python 3" {
-  secrets = ["GITHUB_TOKEN"]
-  uses = "cclauss/Upgrade-to-Python3@master"
-}

--- a/does_it_work.py
+++ b/does_it_work.py
@@ -1,6 +1,6 @@
 try:
     xrange
-except NameError, e:
+except NameError as e:
     pass
 
 print "Hello"


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.